### PR TITLE
Support MD5-encrypted password

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -4,4 +4,5 @@ MRuby::Gem::Specification.new('mruby-trusterd-basicauth') do |spec|
   spec.version = '0.0.1'
   spec.summary = 'Basic Auth for Trusterd'
   spec.add_dependency 'mruby-crypt'
+  spec.add_dependency 'mruby-io'
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -2,6 +2,6 @@ MRuby::Gem::Specification.new('mruby-trusterd-basicauth') do |spec|
   spec.license = 'MIT'
   spec.authors = 'qtkmz, trusterd organization'
   spec.version = '0.0.1'
-  spec.summary = 'Basi Auth for Trusterd'
-  spec.add_dependency 'mruby-base64'
+  spec.summary = 'Basic Auth for Trusterd'
+  spec.add_dependency 'mruby-crypt'
 end

--- a/mrblib/basic_auth.rb
+++ b/mrblib/basic_auth.rb
@@ -1,18 +1,66 @@
 module HTTP2
   class Server
     class BasicAuth
-      def initialize(file)
-        @users = {}
-        IO.open(IO.sysopen((file))) do |io|
-          io.each do |line|
-            params = line.chomp.split(":")
-            @users[params[0]] = params[1]  if 1 < params.size
-          end
-        end
+      def initialize(config)
+        @config = {
+          :realm_name => "Private page",
+        }.merge(config)
+        raise ArgumentError  unless @config.key?(:htpasswd)
+
+        @users = Htpasswd.load(@config[:htpasswd])
       end
 
-      def auth(user, password)
-        @users.key?(user) && @users[user] == password
+      def authn(s)
+        if s.r.headers_in["authorization"].nil?
+          s.r.headers_out["www-authenticate"] = %Q(Basic realm="#{@config[:realm_name]}")
+          s.set_status 401
+          return false
+        end
+
+        auth = s.r.headers_in["authorization"]
+        params = auth.split(" ")[1].unpack("m")[0].split(":")
+        if params[0] == "" || params[1] == "" || !@users.key?(params[0])
+          s.r.headers_out["www-authenticate"] = %Q(Basic realm="#{@config[:realm_name]}")
+          s.set_status 401
+          return false
+        end
+
+        pwd = Crypt::APRMD5.encrypt(params[1], @users[params[0]]) || ""
+        if pwd == "" || @users[params[0]] != pwd
+          s.r.headers_out["www-authenticate"] = %Q(Basic realm="#{@config[:realm_name]}")
+          s.set_status 401
+          return false
+        end
+        return true
+      end
+
+      def self.parse(s)
+         return nil  if s.nil? || s == "" || s[0] == "#"
+         params = s.split(":", 3)
+         return nil  if params.length < 2
+
+         {:username => params[0], :password => params[1]}
+       end
+    end
+
+    class Htpasswd
+      def self.load(filename)
+        users = {}
+        IO.open(IO.sysopen((filename))) do |io|
+          io.each do |line|
+            user = Htpasswd.parse(line.chomp)
+            users[user[:username]] = user[:password]  unless user.nil?
+          end
+        end
+        users
+      end
+
+      def self.parse(s)
+        return nil  if s.nil? || s == "" || s[0] == "#"
+        params = s.split(":", 3)
+        return nil  if params.length < 2
+
+        {:username => params[0], :password => params[1]}
       end
     end
   end


### PR DESCRIPTION
Support the file format of htpasswd.
but it supports only "$apr1$" format.
- config example

```
basic = HTTP2::Server::BasicAuth.new({
  :realm_name  => "Private Area",
  :htpasswd    => "/usr/local/trusterd/conf/htpasswd",
})

s.set_access_checker_cb {
  basic.authn(s)
}
```
